### PR TITLE
chore: Upgrade django-allauth to 65.8.1 to get the patch for fix the fido2 compatibility

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ flower==2.0.1  # https://github.com/mher/flower
 django==5.1.9  # pyup: < 5.2 # https://www.djangoproject.com/
 django-environ==0.12.0  # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
-django-allauth[mfa]==65.8.0  # https://github.com/pennersr/django-allauth
+django-allauth[mfa]==65.8.1  # https://github.com/pennersr/django-allauth
 django-crispy-forms==2.4  # https://github.com/django-crispy-forms/django-crispy-forms
 crispy-bootstrap5==2025.4  # https://github.com/django-crispy-forms/crispy-bootstrap5
 django-redis==5.4.0  # https://github.com/jazzband/django-redis


### PR DESCRIPTION
### Descrição

Correção do problema na lib django-allauth, com o upgrade para versão 65.8.1, que corrige o erro do fido2 (lib secundária)